### PR TITLE
Prevent error if directory already exists

### DIFF
--- a/src/spid_sp_test/html_report.py
+++ b/src/spid_sp_test/html_report.py
@@ -25,7 +25,7 @@ def render_html_report(data:dict,
 
     page_fname = f'{output_folder}/index.html'
     try:
-        os.mkdir(output_folder)
+        os.makedirs(output_folder, exist_ok=True)
         shutil.copytree(f'{template_search_path}/static',
                         f'{output_folder}/static')
     except FileExistsError as e:

--- a/src/spid_sp_test/spid_sp_test
+++ b/src/spid_sp_test/spid_sp_test
@@ -279,7 +279,7 @@ if __name__ == '__main__':
         )
 
         if args.html_path:
-            os.mkdir(html_path)
+            os.makedirs(html_path, exist_ok=True)
 
         response_check = SpidSpResponseCheck(**data_tr)
         selective_run(response_check, profile, args.list)


### PR DESCRIPTION
This PR adds a minor change to the report generation. If the given directory already exists, the script doesn't fail (same behaviour of `mkdir -p`).