### PR TITLE
Add python3-pip to the list of required packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Setup
 -----
 
 ````
-apt install libxml2-dev libxmlsec1-dev libxmlsec1-openssl xmlsec1
+apt install libxml2-dev libxmlsec1-dev libxmlsec1-openssl xmlsec1 python3-pip
 pip install spid-sp-test --upgrade --no-cache
 ````
 


### PR DESCRIPTION
At least in Ubuntu 20.04, it seems like it's not installed by default