### PR TITLE
v0.9.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ example/metadata/*.md
 *pyFF_example/garr
 *pyFF_example/entities
 env/
-*.json
 *egg-info*
 *.log
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ _pkg_name = 'spid_sp_test'
 
 setup(
     name=_pkg_name,
-    version='0.9.6',
+    version='0.9.7',
     description="SAML2 SPID Service Provider validation tool that can be run from the command line",
     long_description=readme(),
     long_description_content_type='text/markdown',

--- a/src/spid_sp_test/authn_request.py
+++ b/src/spid_sp_test/authn_request.py
@@ -1,5 +1,3 @@
-import re
-
 import base64
 import binascii
 import copy

--- a/src/spid_sp_test/authn_request.py
+++ b/src/spid_sp_test/authn_request.py
@@ -378,17 +378,6 @@ class SpidSpAuthnReqCheck(AbstractSpidCheck):
         )
         return self.is_ok(f"{self.__class__.__name__}.test_xmldsig")
 
-    def test_authnrequest_no_newlines(self):
-        self._assertFalse(
-            re.match(r"^[\t\n\s\r\ ]*", self.authn_request_decoded),
-            (
-                "The XML of authn request should not "
-                "contains newlines at the beginning."
-            ),
-            description=self.metadata[0:10],
-            level="warning",
-        )
-        return self.is_ok(f"{self.__class__.__name__}.test_authnrequest_no_newlines")
 
     def test_AuthnRequest(self):
         """Test the compliance of AuthnRequest element"""

--- a/src/spid_sp_test/authn_request.py
+++ b/src/spid_sp_test/authn_request.py
@@ -616,47 +616,6 @@ class SpidSpAuthnReqCheck(AbstractSpidCheck):
             )
         return self.is_ok(f"{self.__class__.__name__}.test_AuthnRequest_SPID")
 
-    def test_AuthnRequest_SPID_extra(self):
-        """Test the compliance of AuthnRequest element"""
-
-        # ForceAuthn MUST be true if 'Comparison' is 'minimum' and
-        # SPID level is L1
-
-        req = self.doc.xpath("/AuthnRequest")
-        rac = None
-        acr = None
-        if req:
-            rac = req[0].xpath("./RequestedAuthnContext")
-        if rac:
-            acr = rac[0].xpath("./AuthnContextClassRef")
-
-        if req and rac and acr:
-            req = req[0]
-            rac = rac[0]
-            acr = acr[0]
-
-            if rac.get("Comparison") in ("minimum", "exact") and acr.text in (
-                "https://www.spid.gov.it/SpidL2",
-                "https://www.spid.gov.it/SpidL3",
-            ):
-                self._assertTrue(
-                    ("ForceAuthn" in req.attrib),
-                    "The ForceAuthn attribute MUST be present "
-                    "because of minimum/SpidL2",
-                    description=req.attrib,
-                )
-                self._assertTrue(
-                    req.get("ForceAuthn", "").lower() in ("true", 1, "1"),
-                    "The ForceAuthn attribute MUST be True "
-                    "because of minimum/SpidL2",
-                    description=req.attrib,
-                )
-        else:
-            self.handle_error(
-                "AuthnRequest or RequestAuthnContext or AuthnContextClassRef missing"
-            )
-
-        return self.is_ok(f"{self.__class__.__name__}.test_AuthnRequest_extra")
 
     def test_Subject(self):
         """Test the compliance of Subject element"""
@@ -1012,6 +971,5 @@ class SpidSpAuthnReqCheck(AbstractSpidCheck):
         self.test_Signature()
         self.test_xmldsig()
         self.test_AuthnRequest_SPID()
-        self.test_AuthnRequest_SPID_extra()
         self.test_NameIDPolicy()
         self.test_RequestedAuthnContext()

--- a/src/spid_sp_test/authn_request_extra.py
+++ b/src/spid_sp_test/authn_request_extra.py
@@ -1,3 +1,5 @@
+import re
+
 from . authn_request import SpidSpAuthnReqCheck
 
 

--- a/src/spid_sp_test/authn_request_extra.py
+++ b/src/spid_sp_test/authn_request_extra.py
@@ -1,0 +1,56 @@
+from . authn_request import SpidSpAuthnReqCheck
+
+
+class SpidSpAuthnReqCheckExtra(SpidSpAuthnReqCheck):
+
+    def __init__(self, *args, **kwargs):
+
+        super(SpidSpAuthnReqCheckExtra, self).__init__(*args, **kwargs)
+        self.category = "authnrequest_extra"
+
+    def test_AuthnRequest_SPID_extra(self):
+        """Test the compliance of AuthnRequest element"""
+
+        # ForceAuthn MUST be true if 'Comparison' is 'minimum' and
+        # SPID level is L1
+
+        req = self.doc.xpath("/AuthnRequest")
+        rac = None
+        acr = None
+        if req:
+            rac = req[0].xpath("./RequestedAuthnContext")
+        if rac:
+            acr = rac[0].xpath("./AuthnContextClassRef")
+
+        if req and rac and acr:
+            req = req[0]
+            rac = rac[0]
+            acr = acr[0]
+
+            if rac.get("Comparison") in ("minimum", "exact") and acr.text in (
+                "https://www.spid.gov.it/SpidL2",
+                "https://www.spid.gov.it/SpidL3",
+            ):
+                self._assertTrue(
+                    ("ForceAuthn" in req.attrib),
+                    "The ForceAuthn attribute MUST be present "
+                    "because of minimum/SpidL2",
+                    description=req.attrib,
+                )
+                self._assertTrue(
+                    req.get("ForceAuthn", "").lower() in ("true", 1, "1"),
+                    "The ForceAuthn attribute MUST be True "
+                    "because of minimum/SpidL2",
+                    description=req.attrib,
+                )
+        else:
+            self.handle_error(
+                "AuthnRequest or RequestAuthnContext or AuthnContextClassRef missing"
+            )
+
+        return self.is_ok(f"{self.__class__.__name__}.test_AuthnRequest_extra")
+
+
+    def test_profile_spid_sp(self):
+        super().test_profile_spid_sp()
+        self.test_AuthnRequest_SPID_extra()

--- a/src/spid_sp_test/authn_request_extra.py
+++ b/src/spid_sp_test/authn_request_extra.py
@@ -51,6 +51,19 @@ class SpidSpAuthnReqCheckExtra(SpidSpAuthnReqCheck):
         return self.is_ok(f"{self.__class__.__name__}.test_AuthnRequest_extra")
 
 
+    def test_authnrequest_no_newlines(self):
+        self._assertFalse(
+            re.match(r"^[\t\n\s\r\ ]*", self.authn_request_decoded),
+            (
+                "The XML of authn request should not "
+                "contains newlines at the beginning."
+            ),
+            description=self.metadata[0:10],
+            level="warning",
+        )
+        return self.is_ok(f"{self.__class__.__name__}.test_authnrequest_no_newlines")
+
+
     def test_profile_spid_sp(self):
         super().test_profile_spid_sp()
         self.test_AuthnRequest_SPID_extra()

--- a/src/spid_sp_test/metadata.py
+++ b/src/spid_sp_test/metadata.py
@@ -1,5 +1,3 @@
-import re
-
 from spid_sp_test.utils import del_ns
 from spid_sp_test import constants
 from spid_sp_test import BASE_DIR, AbstractSpidCheck

--- a/src/spid_sp_test/metadata.py
+++ b/src/spid_sp_test/metadata.py
@@ -92,15 +92,6 @@ class SpidSpMetadataCheck(
         os.chdir(_orig_pos)
         return self.is_ok(f"{self.__class__.__name__}.xsd_check")
 
-    def test_metadata_no_newlines(self):
-        self._assertFalse(
-            re.match(r"^[\t\n\s\r\ ]*", self.metadata),
-            ("The XML of metadata should not " "contains newlines at the beginning."),
-            description=self.metadata[0:10],
-            level="warning",
-        )
-        return self.is_ok(f"{self.__class__.__name__}.test_metadata_no_newlines")
-
     def test_EntityDescriptor(self):
         entity_desc = self.doc.xpath("//EntityDescriptor")
 
@@ -134,13 +125,6 @@ class SpidSpMetadataCheck(
                 self.doc.attrib.get("entityID"),
                 'The entityID attribute MUST not contains any custom tcp ports, eg: ":8000"',
             )
-
-        self._assertTrue(
-            (self.doc.attrib.get("entityID") == self.metadata_url),
-            f"The EntityID MUST be equal to {self.metadata_url}",
-            description=f"{self.doc.attrib.get('entityID')}",
-            level="warning",
-        )
 
         return self.is_ok(f"{self.__class__.__name__}.test_EntityDescriptor")
 

--- a/src/spid_sp_test/metadata_extra.py
+++ b/src/spid_sp_test/metadata_extra.py
@@ -15,6 +15,24 @@ class SpidSpMetadataCheckExtra(SpidSpMetadataCheck):
         super(SpidSpMetadataCheckExtra, self).__init__(*args, **kwargs)
         self.category = "metadata_extra"
 
+    def test_metadata_no_newlines(self):
+        self._assertFalse(
+            re.match(r"^[\t\n\s\r\ ]*", self.metadata),
+            ("The XML of metadata should not " "contains newlines at the beginning."),
+            description=self.metadata[0:10],
+            level="warning",
+        )
+        return self.is_ok(f"{self.__class__.__name__}.test_metadata_no_newlines")
+
+    def test_entityid_match_url(self):
+        self._assertTrue(
+            (self.doc.attrib.get("entityID") == self.metadata_url),
+            f"The EntityID SHOULD be equal to {self.metadata_url}",
+            description=f"{self.doc.attrib.get('entityID')}",
+            level="warning",
+        )
+        return self.is_ok(f"{self.__class__.__name__}.test_entityid_match_url")
+
     def test_Signature_extra(self):
         """Test the compliance of AuthnRequest element"""
 

--- a/src/spid_sp_test/metadata_extra.py
+++ b/src/spid_sp_test/metadata_extra.py
@@ -1,5 +1,6 @@
 import datetime
 import os
+import re
 
 from lxml import etree
 from spid_sp_test import constants

--- a/src/spid_sp_test/spid_sp_test
+++ b/src/spid_sp_test/spid_sp_test
@@ -243,6 +243,18 @@ if __name__ == '__main__':
         )
     )
 
+    parser.add_argument(
+        '-prs', '--print-responses-settings',
+        required=False, action="store_true",
+        help='print out the default responses settings'
+    )
+
+    parser.add_argument(
+        '-pas', '--print-attributes-settings',
+        required=False, action="store_true",
+        help='print out the default user attributes used in automatic responses'
+    )
+
     args = parser.parse_args()
     logging.basicConfig(level=getattr(logging, args.debug))
 
@@ -259,6 +271,16 @@ if __name__ == '__main__':
         idp_server = Server(SAML2_IDP_CONFIG)
         idp_metadata = entity_descriptor(idp_server.config)
         print(idp_metadata.to_string().decode())
+        sys.exit(0)
+
+    elif args.print_responses_settings:
+        from spid_sp_test.responses.settings import RESPONSE_TESTS
+        print(json.dumps(RESPONSE_TESTS, indent=2))
+        sys.exit(0)
+
+    elif args.print_attributes_settings:
+        from spid_sp_test.responses.settings import ATTRIBUTES
+        print(json.dumps(ATTRIBUTES, indent=2))
         sys.exit(0)
 
     elif args.metadata_url:

--- a/src/spid_sp_test/spid_sp_test
+++ b/src/spid_sp_test/spid_sp_test
@@ -12,6 +12,7 @@ from spid_sp_test import BASE_DIR
 from spid_sp_test.metadata import SpidSpMetadataCheck
 from spid_sp_test.metadata_extra import SpidSpMetadataCheckExtra
 from spid_sp_test.authn_request import SpidSpAuthnReqCheck
+from spid_sp_test.authn_request_extra import SpidSpAuthnReqCheckExtra
 from spid_sp_test.html_report import render_html_report
 from spid_sp_test.response import SpidSpResponseCheck
 from spid_sp_test.utils import get_xmlsec1_bin
@@ -277,6 +278,10 @@ if __name__ == '__main__':
 
     # authn request
     if args.authn_url:
+        if args.extra:
+            _cls = SpidSpAuthnReqCheckExtra
+        else:
+            _cls = SpidSpAuthnReqCheck
         data_ac = dict(
             metadata = metadata_check.metadata,
             authn_request_url = args.authn_url,
@@ -286,7 +291,7 @@ if __name__ == '__main__':
             request_body = args.request_body,
             request_content_type = args.request_content_type
         )
-        authn_check = SpidSpAuthnReqCheck(**data_ac)
+        authn_check = _cls(**data_ac)
         selective_run(authn_check, profile, args.list)
         tests_done.append(authn_check)
 

--- a/tests/example.attributes.json
+++ b/tests/example.attributes.json
@@ -1,0 +1,14 @@
+{
+  "spidCode": "AGID-001",
+  "name": "SpidValidator",
+  "familyName": "AgID",
+  "placeOfBirth": "Roma",
+  "countyOfBirth": "RM",
+  "dateOfBirth": "2000-01-01",
+  "companyName": "Agenzia per l'Italia Digitale",
+  "companyFiscalNumber": "TINIT-GDASDV00A01H501J",
+  "fiscalNumber": "TINIT-GDASDV00A01H501J",
+  "idCard": "CartaIdentit\u00e0 AA00000000 ComuneRoma 2018-01-01 2028-01-01",
+  "mobilePhone": "+393331234567",
+  "email": "spid.tech@agid.gov.it",
+}

--- a/tests/example.test-suite.json
+++ b/tests/example.test-suite.json
@@ -1,0 +1,54 @@
+{
+  "1": {
+    "name": "01. Response corretta",
+    "description": "Response corretta. Risultato atteso: Ok",
+    "status_codes": [
+      200
+    ],
+    "path": "base.xml",
+    "response": {}
+  },
+  "2": {
+    "name": "02. Response non firmata",
+    "description": "Response non firmata. Risultato atteso: KO",
+    "status_codes": [
+      400,
+      401,
+      403,
+      422,
+      500
+    ],
+    "path": "case-02.xml",
+    "response": {}
+  },
+  "3": {
+    "name": "03. Response - Assertion non firmata",
+    "description": "Response firmata, Assertion non firmata. (L'assertion deve essere sempre firmata, la response pu\u00f2 essere firmata)",
+    "status_codes": [
+      400,
+      401,
+      403,
+      422,
+      500
+    ],
+    "path": "case-03.xml",
+    "response": {}
+  },
+  "4": {
+    "name": "04. Response - Firma non valida",
+    "description": "Response firmata con certificato diverso da quello registrato su SP. Risultato atteso: KO",
+    "status_codes": [
+      400,
+      401,
+      403,
+      422,
+      500
+    ],
+    "path": "base.xml",
+    "response": {},
+    "sign_credentials": {
+      "certificate": "/home/wert/DEV4/DTD/Spid/spid_sp_test/src/spid_sp_test/responses/certificates/test_public.cert",
+      "privateKey": "/home/wert/DEV4/DTD/Spid/spid_sp_test/src/spid_sp_test/responses/certificates/test_private.key"
+    }
+  }
+}


### PR DESCRIPTION
- chore: authn request extra in a separate class
- chore: all the warnings have been moved to extrs, fixes https://github.com/italia/spid-sp-test/issues/43
- fix: IssueInstantMillis to be a valid SAML instant in responses test (@mauromol )
- feat: added -prs and -pas to print out default responses and user attributes settings


