### PR TITLE
v0.9.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ _pkg_name = 'spid_sp_test'
 
 setup(
     name=_pkg_name,
-    version='0.9.10',
+    version='0.9.11',
     description="SAML2 SPID Service Provider validation tool that can be run from the command line",
     long_description=readme(),
     long_description_content_type='text/markdown',

--- a/src/spid_sp_test/__init__.py
+++ b/src/spid_sp_test/__init__.py
@@ -101,11 +101,13 @@ class AbstractSpidCheck(object):
         level: str = "info",
         **kwargs,
     ):
-        if not check and level != "warning":
-            self.handle_error(error_message, description, traceback, **kwargs)
-        else:
-            # level = "info" if level in ("warning",) else level
-            self.handle_result(level, error_message, description, traceback, **kwargs)
+        if level == 'warning':
+            # overwrite to info is warning doens't happen.
+            if check:
+                level = "info"
+        elif not check:
+            level = 'error'
+        self.handle_result(level, error_message, description, traceback, **kwargs)
 
     def _assertTrue(self, *args, **kwargs):
         self._assert(*args, **kwargs)

--- a/src/spid_sp_test/__init__.py
+++ b/src/spid_sp_test/__init__.py
@@ -101,12 +101,12 @@ class AbstractSpidCheck(object):
         level: str = "info",
         **kwargs,
     ):
-        if level == 'warning':
+        if level == "warning":
             # overwrite to info is warning doens't happen.
             if check:
                 level = "info"
         elif not check:
-            level = 'error'
+            level = "error"
         self.handle_result(level, error_message, description, traceback, **kwargs)
 
     def _assertTrue(self, *args, **kwargs):

--- a/src/spid_sp_test/authn_request.py
+++ b/src/spid_sp_test/authn_request.py
@@ -707,11 +707,11 @@ class SpidSpAuthnReqCheck(AbstractSpidCheck):
             )
         # Not shure that this must be checked :)
         # elif len(subj) < 1:
-            # self._assertTrue(
-                # False,
-                # "The Subject element MUST be present",
-                # **_data,
-            # )
+        # self._assertTrue(
+        # False,
+        # "The Subject element MUST be present",
+        # **_data,
+        # )
         elif len(subj) == 1:
             subj = subj[0]
             name_id = subj.xpath("./NameID")
@@ -903,12 +903,12 @@ class SpidSpAuthnReqCheck(AbstractSpidCheck):
             )
         # Not shure that this must be checked :)
         # elif len(e) < 1:
-            # self._assertTrue(
-                # e,
-                # "The Conditions element MUST be present",
-                # **_data,
-            # )
-            # return self.is_ok(_method)
+        # self._assertTrue(
+        # e,
+        # "The Conditions element MUST be present",
+        # **_data,
+        # )
+        # return self.is_ok(_method)
 
         elif len(e) == 1:
             e = e[0]

--- a/src/spid_sp_test/constants.py
+++ b/src/spid_sp_test/constants.py
@@ -163,7 +163,7 @@ FICEP_FULL_ATTRIBUTES = [
 ]
 
 NODE_NAME = "urn:oasis:names:tc:SAML:2.0:assertion:Assertion"
-EMAIL_REGEXP = "^(\w|\.|\_|\-)+[@](\w|\_|\-|\.)+[.]\w{2,6}$"
+EMAIL_REGEXP = r"^(\w|\.|\_|\-)+[@](\w|\_|\-|\.)+[.]\w{2,6}$"
 
 
 ISO3166_CODES = [

--- a/src/spid_sp_test/metadata.py
+++ b/src/spid_sp_test/metadata.py
@@ -210,7 +210,7 @@ class SpidSpMetadataCheck(
 
     def test_xmldsig(self):
         """Verify the SP metadata signature"""
-        tmp_file = NamedTemporaryFile()
+        tmp_file = NamedTemporaryFile(suffix=".xml")
         tmp_file.write(self.metadata)
         tmp_file.seek(0)
         xmlsec_cmd = [
@@ -833,7 +833,9 @@ class SpidSpMetadataCheck(
         self.test_Contacts_PubPriv(entity_type="spid:aggregated")
 
         # TODO
-        # If the ContactPerson is of spid:entityType “spid:aggregator” the Extensions element MUST contain the element spid:KeyDescriptor with attribute use “spid:validation”
+        # If the ContactPerson is of spid:entityType “spid:aggregator”
+        # the Extensions element MUST contain the element spid:KeyDescriptor
+        # with attribute use “spid:validation”
 
         # The PublicServicesLightAggregator element MUST be present
         self.test_extensions_public_ag(

--- a/src/spid_sp_test/metadata.py
+++ b/src/spid_sp_test/metadata.py
@@ -66,7 +66,7 @@ class SpidSpMetadataCheck(
 
     def xsd_check(self, xsds_files: list = ["saml-schema-metadata-2.0.xsd"]):
         _method = f"{self.__class__.__name__}.xsd_check"
-        test_id = ['1.0.0']
+        test_id = ["1.0.0"]
         logger.debug(self.metadata.decode())
         _orig_pos = os.getcwd()
         os.chdir(self.xsds_files_path)
@@ -84,7 +84,7 @@ class SpidSpMetadataCheck(
                         description=msg,
                         references="",
                         method=_method,
-                        test_id = test_id
+                        test_id=test_id,
                     )
                     # raise Exception('Validation Error')
                 break
@@ -97,7 +97,7 @@ class SpidSpMetadataCheck(
                     description="xsd test failed",
                     traceback=f"{e}",
                     method=_method,
-                    test_id = test_id
+                    test_id=test_id,
                 )
         os.chdir(_orig_pos)
         if not self.errors:
@@ -117,14 +117,16 @@ class SpidSpMetadataCheck(
         self._assertTrue(
             len(entity_desc) == 1,
             "Only one EntityDescriptor element MUST be present",
-            description=desc, test_id = ['1.3.0'],
+            description=desc,
+            test_id=["1.3.0"],
             **_data,
         )
 
         self._assertTrue(
             self.doc.attrib.get("entityID"),
             "The entityID attribute MUST be present",
-            description=self.doc.attrib, test_id = ['1.3.1'],
+            description=self.doc.attrib,
+            test_id=["1.3.1"],
             **_data,
         )
 
@@ -132,7 +134,8 @@ class SpidSpMetadataCheck(
             entity_desc[0].get("entityID"),
             "The entityID attribute MUST have a value",
             description=entity_desc[0].get("entityID"),
-            **_data, test_id = ['1.3.2'],
+            **_data,
+            test_id=["1.3.2"],
         )
 
         if self.production:
@@ -154,7 +157,9 @@ class SpidSpMetadataCheck(
         desc = [etree.tostring(ent).decode()[:128] for ent in spsso if spsso]
 
         _method = f"{self.__class__.__name__}.test_SPSSODescriptor"
-        _data = dict(test_id="", references=[""], method=_method, description=desc)
+        _data = dict(
+            test_id=["1.6.0"], references=[""], method=_method, description=desc
+        )
 
         self._assertTrue(
             (len(spsso) == 1),
@@ -167,14 +172,13 @@ class SpidSpMetadataCheck(
         spsso = self.doc.xpath("//EntityDescriptor/SPSSODescriptor")
         desc = [etree.tostring(ent).decode()[:128] for ent in spsso if spsso]
         _method = f"{self.__class__.__name__}.test_SPSSODescriptor_SPID"
-        _data = dict(
-            test_id="", references=["TR pag. 20"], method=_method, description=desc
-        )
+        _data = dict(references=["TR pag. 20"], method=_method, description=desc)
 
         for attr in ["protocolSupportEnumeration", "AuthnRequestsSigned"]:
             self._assertTrue(
                 (attr in spsso[0].attrib),
                 f"The {attr} attribute MUST be present",
+                test_id=["1.6.1", "1.6.3"],
                 **_data,
             )
 
@@ -182,6 +186,7 @@ class SpidSpMetadataCheck(
             self._assertTrue(
                 a,
                 f"The {attr} attribute MUST have a value",
+                test_id=["1.6.2", "1.6.4"],
                 **_data,
             )
 
@@ -189,6 +194,7 @@ class SpidSpMetadataCheck(
                 self._assertTrue(
                     a.lower() == "true",
                     f"The {attr} attribute MUST be true",
+                    test_id=["1.6.5"],
                     **_data,
                 )
 
@@ -230,7 +236,7 @@ class SpidSpMetadataCheck(
         msg = "the metadata signature MUST be valid"
 
         _data = dict(
-            test_id="",
+            test_id=["1.9.0"],
             references=["TR pag. 19"],
             method=f"{self.__class__.__name__}.test_xmldsig",
         )
@@ -271,7 +277,6 @@ class SpidSpMetadataCheck(
         desc = [etree.tostring(ent).decode() for ent in sign if sign]
 
         _data = dict(
-            test_id="",
             description="".join(desc)[:128] or "",
             references=["TR pag. 19"],
             method=_method,
@@ -280,6 +285,7 @@ class SpidSpMetadataCheck(
         self._assertTrue(
             (len(sign) > 0),
             "The Signature element MUST be present",
+            test_id=["1.7.0"],
             **_data,
         )
 
@@ -287,22 +293,26 @@ class SpidSpMetadataCheck(
             self.handle_result(
                 "error",
                 "The SignatureMethod element MUST be present",
+                test_id=["1.7.1"],
                 **_data,
             )
             self.handle_result(
                 "error",
                 "The Algorithm attribute MUST be present in SignatureMethod element",
+                test_id=["1.7.2"],
                 **_data,
             )
             self.handle_result(
                 "error",
                 "The signature algorithm MUST be valid",
                 description=f"Must be one of [{', '.join(constants.ALLOWED_XMLDSIG_ALGS)}]",
+                test_id=["1.7.3"],
                 **_data,
             )
             self.handle_result(
                 "error",
                 "The Algorithm attribute MUST be present in DigestMethod element",
+                test_id=["1.7.4"],
                 **_data,
             )
 
@@ -311,6 +321,7 @@ class SpidSpMetadataCheck(
                 "error",
                 "The digest algorithm MUST be valid",
                 description=f"Must be one of [{', '.join(constants.ALLOWED_DGST_ALGS)}]",
+                test_id=["1.7.5"],
                 **_data,
             )
         else:
@@ -320,6 +331,7 @@ class SpidSpMetadataCheck(
             self._assertTrue(
                 (len(method) > 0),
                 "The SignatureMethod element MUST be present",
+                test_id=["1.7.1"],
                 **_data,
             )
 
@@ -335,6 +347,7 @@ class SpidSpMetadataCheck(
                 alg in constants.ALLOWED_XMLDSIG_ALGS,
                 "The signature algorithm MUST be valid",
                 description=f"One of {(', '.join(constants.ALLOWED_XMLDSIG_ALGS))}",
+                test_id=["1.7.3"],
                 **_data,
             )
 
@@ -342,12 +355,14 @@ class SpidSpMetadataCheck(
             self._assertTrue(
                 (len(method) == 1),
                 "The DigestMethod element MUST be present",
+                test_id=["1.7.4"],
                 **_data,
             )
 
             self._assertTrue(
                 ("Algorithm" in method[0].attrib),
                 "The Algorithm attribute MUST be present in DigestMethod element",
+                test_id=["1.7.5"],
                 **_data,
             )
 
@@ -356,6 +371,7 @@ class SpidSpMetadataCheck(
                 alg in constants.ALLOWED_DGST_ALGS,
                 "The digest algorithm MUST be valid",
                 description=f"One of {(', '.join(constants.ALLOWED_DGST_ALGS))}",
+                test_id=["1.7.6"],
                 **_data,
             )
 
@@ -369,8 +385,10 @@ class SpidSpMetadataCheck(
         )
         _data = dict(references=["TR pag. 19"], method=_method)
         self._assertTrue(
-            len(kds) >= 1, "At least one signing KeyDescriptor MUST be present",
-            test_id = ['1.4.0'], **_data
+            len(kds) >= 1,
+            "At least one signing KeyDescriptor MUST be present",
+            test_id=["1.4.0"],
+            **_data,
         )
 
         desc = [etree.tostring(ent).decode() for ent in kds if kds]
@@ -381,7 +399,8 @@ class SpidSpMetadataCheck(
                 len(certs) >= 1,
                 "At least one signing x509 MUST be present",
                 description="".join(desc)[:128] or "",
-                test_id = ['1.4.1'], **_data,
+                test_id=["1.4.1"],
+                **_data,
             )
 
         kds = self.doc.xpath(
@@ -393,7 +412,8 @@ class SpidSpMetadataCheck(
             self._assertTrue(
                 len(certs) >= 1,
                 "At least one encryption x509 MUST be present",
-                test_id = ['1.4.2'], **_data,
+                test_id=["1.4.2"],
+                **_data,
             )
 
         return self.is_ok(_method)
@@ -406,7 +426,6 @@ class SpidSpMetadataCheck(
         _method = f"{self.__class__.__name__}.test_SingleLogoutService"
         desc = [etree.tostring(ent).decode() for ent in slos if slos]
         _data = dict(
-            test_id="",
             references=["AV n. 3"],
             method=_method,
             description="".join(desc)[:128],
@@ -415,6 +434,7 @@ class SpidSpMetadataCheck(
         self._assertTrue(
             len(slos) >= 1,
             "One or more SingleLogoutService elements MUST be present",
+            test_id=["1.8.0"],
             **_data,
         )
 
@@ -423,6 +443,7 @@ class SpidSpMetadataCheck(
                 self._assertTrue(
                     (attr in slo.attrib),
                     f"The {attr} attribute in SingleLogoutService element MUST be present",
+                    test_id=["1.8.1", "1.8.4"],
                     **_data,
                 )
 
@@ -430,6 +451,7 @@ class SpidSpMetadataCheck(
                 self._assertTrue(
                     _attr,
                     f"The {attr} attribute in SingleLogoutService element MUST have a value",
+                    test_id=["1.8.2", "1.8.5"],
                     **_data,
                 )
 
@@ -442,6 +464,7 @@ class SpidSpMetadataCheck(
                             )
                             % (attr, ", ".join(constants.ALLOWED_BINDINGS))  # noqa
                         ),
+                        test_id=["1.8.3"],
                         **_data,  # noqa
                     )
                 if attr == "Location" and self.production:
@@ -450,6 +473,7 @@ class SpidSpMetadataCheck(
                         f"The {attr} attribute "
                         "in SingleLogoutService element "
                         "MUST be a valid HTTPS URL",
+                        test_id=["1.8.6"],
                         **_data,
                     )
                     self._assertHttpUrlWithoutPort(
@@ -484,7 +508,8 @@ class SpidSpMetadataCheck(
         self._assertTrue(
             len(acss) >= 1,
             "At least one AssertionConsumerService MUST be present",
-            test_id = ['1.1.0'], **_data,
+            test_id=["1.1.0"],
+            **_data,
         )
 
         for acs in acss:
@@ -492,14 +517,16 @@ class SpidSpMetadataCheck(
                 self._assertTrue(
                     (attr in acs.attrib),
                     f"The {attr} attribute MUST be present",
-                    test_id = ['1.1.1', '1.1.3', '1.1.5'], **_data,
+                    test_id=["1.1.1", "1.1.3", "1.1.5"],
+                    **_data,
                 )
                 _attr = acs.get(attr)
                 if attr == "index":
                     self._assertTrue(
                         int(_attr) >= 0,
                         f"The {attr} attribute MUST be >= 0",
-                        test_id = ['1.1.2'], **_data,
+                        test_id=["1.1.2"],
+                        **_data,
                     )
                 elif attr == "Binding":
                     self._assertTrue(
@@ -508,18 +535,21 @@ class SpidSpMetadataCheck(
                             ("The %s attribute MUST be one of [%s]")
                             % (attr, ", ".join(constants.ALLOWED_BINDINGS))
                         ),
-                        test_id = ['1.1.4'], **_data,
+                        test_id=["1.1.4"],
+                        **_data,
                     )
                 elif attr == "Location" and self.production:
                     self._assertIsValidHttpsUrl(
                         _attr,
                         f"The {attr} attribute MUST be a valid HTTPS url",
-                        test_id = ['1.1.6'], **_data,
+                        test_id=["1.1.6"],
+                        **_data,
                     )
                     self._assertHttpUrlWithoutPort(
                         _attr,
                         'The entityID attribute MUST not contain any custom tcp ports, eg: ":8000"',
-                        test_id = ['1.1.6'], **_data,
+                        test_id=["1.1.6"],
+                        **_data,
                     )
                 else:
                     pass
@@ -543,7 +573,8 @@ class SpidSpMetadataCheck(
         self._assertTrue(
             (len(acss) == 1),
             "Only one default AssertionConsumerService MUST be present",
-            test_id = ['1.1.7'], **_data,
+            test_id=["1.1.7"],
+            **_data,
         )
 
         acss = self.doc.xpath(
@@ -555,7 +586,8 @@ class SpidSpMetadataCheck(
         self._assertTrue(
             (len(acss) == 1),
             "Must be present the default AssertionConsumerService with index = 0",
-            test_id = ['1.1.8'], **_data,
+            test_id=["1.1.8"],
+            **_data,
         )
         return self.is_ok(_method)
 
@@ -575,7 +607,8 @@ class SpidSpMetadataCheck(
         self._assertTrue(
             len(acss) >= 1,
             "One or more AttributeConsumingService elements MUST be present",
-            test_id = ['1.2.0'], **_data,
+            test_id=["1.2.0"],
+            **_data,
         )
         return self.is_ok(_method)
 
@@ -596,41 +629,52 @@ class SpidSpMetadataCheck(
             self._assertTrue(
                 ("index" in acs.attrib),
                 "The index attribute in AttributeConsumigService element MUST be present",
-                description=_desc, test_id = ['1.2.1'], **_data,
+                description=_desc,
+                test_id=["1.2.1"],
+                **_data,
             )
 
             idx = int(acs.get("index"))
             self._assertTrue(
                 idx >= 0,
                 "The index attribute in AttributeConsumigService element MUST be >= 0",
-                description=_desc, test_id = ['1.2.2'], **_data,
+                description=_desc,
+                test_id=["1.2.2"],
+                **_data,
             )
 
             sn = acs.xpath("./ServiceName")
             self._assertTrue(
                 (len(sn) > 0),
                 "The ServiceName element MUST be present",
-                description=_desc, test_id = ['1.2.3'], **_data,
+                description=_desc,
+                test_id=["1.2.3"],
+                **_data,
             )
             for sns in sn:
                 self._assertTrue(
                     sns.text,
                     "The ServiceName element MUST have a value",
-                    description=_desc, test_id = ['1.2.4'], **_data,
+                    description=_desc,
+                    test_id=["1.2.4"],
+                    **_data,
                 )
 
             ras = acs.xpath("./RequestedAttribute")
             self._assertTrue(
                 len(ras) >= 1,
                 "One or more RequestedAttribute elements MUST be present",
-                description=_desc, test_id = ['1.2.5'], **_data,
+                description=_desc,
+                test_id=["1.2.5"],
+                **_data,
             )
 
             for ra in ras:
                 self._assertTrue(
                     ("Name" in ra.attrib),
                     "The Name attribute in RequestedAttribute element "
-                    "MUST be present", test_id = ['1.2.6'],
+                    "MUST be present",
+                    test_id=["1.2.6"],
                     description=_desc,
                     **_data,
                 )
@@ -639,7 +683,8 @@ class SpidSpMetadataCheck(
                     ra.get("Name") in allowed_attributes,
                     f'The "{ra.attrib.values()[0]}" attribute in RequestedAttribute element MUST be valid',
                     description=f"one of [{', '.join(allowed_attributes)}]",
-                    **_data, test_id = ['1.2.7']
+                    **_data,
+                    test_id=["1.2.7"],
                 )
 
             al = acs.xpath("RequestedAttribute/@Name")
@@ -660,8 +705,10 @@ class SpidSpMetadataCheck(
         _data = dict(description=desc, references=["TR pag. 20"], method=_method)
 
         self._assertTrue(
-            (len(orgs) == 1), "Only one Organization element can be present",
-            test_id = ['1.5.0'], **_data
+            (len(orgs) == 1),
+            "Only one Organization element can be present",
+            test_id=["1.5.0"],
+            **_data,
         )
 
         enames = ["OrganizationName", "OrganizationDisplayName", "OrganizationURL"]
@@ -674,7 +721,8 @@ class SpidSpMetadataCheck(
                 self._assertTrue(
                     len(elements) > 0,
                     f"One or more {ename} elements MUST be present",
-                    test_id = ['1.5.1', '1.5.4'], **_data,
+                    test_id=["1.5.1", "1.5.4"],
+                    **_data,
                 )
 
                 for element in elements:
@@ -684,7 +732,8 @@ class SpidSpMetadataCheck(
                             in element.attrib
                         ),  # noqa
                         f"The lang attribute in {ename} element MUST be present",  # noqa
-                        test_id = ['1.5.2', '1.5.5', '1.5.8'], **_data,
+                        test_id=["1.5.2", "1.5.5", "1.5.8"],
+                        **_data,
                     )
 
                     lang = element.attrib.items()[0][1]
@@ -696,7 +745,8 @@ class SpidSpMetadataCheck(
                     self._assertTrue(
                         element.text,
                         f"The {ename} element MUST have a value",
-                        test_id = ['1.5.3', '1.5.7', '1.5.9'], **_data,
+                        test_id=["1.5.3", "1.5.7", "1.5.9"],
+                        **_data,
                     )
 
                     if ename == "OrganizationURL" and self.production:
@@ -709,7 +759,8 @@ class SpidSpMetadataCheck(
                         self._assertIsValidHttpUrl(
                             OrganizationURLvalue,
                             f"The {ename} element MUST be a valid URL",
-                            test_id = ['1.5.10'], **_data,
+                            test_id=["1.5.10"],
+                            **_data,
                         )
 
             # lang counter check
@@ -721,7 +772,8 @@ class SpidSpMetadataCheck(
                         "The elements OrganizationName, OrganizationDisplayName and OrganizationURL "
                         "MUST have the same number of lang attributes"
                     ),  # noqa
-                    test_id = ['1.5.5', '1.5.8'], **_data,
+                    test_id=["1.5.5", "1.5.8"],
+                    **_data,
                 )
 
             self._assertTrue(

--- a/src/spid_sp_test/metadata_extra.py
+++ b/src/spid_sp_test/metadata_extra.py
@@ -120,7 +120,6 @@ class SpidSpMetadataCheckExtra(SpidSpMetadataCheck):
 
         _method = f"{self.__class__.__name__}.test_SPSSODescriptor_extra"
         _data = dict(
-            test_id="",
             references=[],
             method=_method,
         )
@@ -130,6 +129,7 @@ class SpidSpMetadataCheckExtra(SpidSpMetadataCheck):
                 (attr in spsso[0].attrib),
                 f"The {attr} attribute MUST be present",
                 description=spsso[0].attrib,
+                test_id=["1.6.1", "1.6.7"],
                 **_data,
             )
 
@@ -144,13 +144,18 @@ class SpidSpMetadataCheckExtra(SpidSpMetadataCheck):
                     f"The {attr} attribute MUST be "
                     "urn:oasis:names:tc:SAML:2.0:protocol",
                     description=a,
+                    test_id=["1.6.6"],
                     **_data,
                 )
 
             if attr == "WantAssertionsSigned":
                 a = spsso[0].get(attr)
                 self._assertTrue(
-                    a, f"The {attr} attribute MUST have a value", description=a, **_data
+                    a,
+                    f"The {attr} attribute MUST have a value",
+                    description=a,
+                    **_data,
+                    test_id=["1.6.8"],
                 )
 
                 if a:
@@ -158,6 +163,7 @@ class SpidSpMetadataCheckExtra(SpidSpMetadataCheck):
                         a.lower() == "true",
                         f"The {attr} attribute MUST be true",
                         description=a,
+                        test_id=["1.6.9"],
                         **_data,
                     )
         return self.is_ok(_method)

--- a/src/spid_sp_test/metadata_private.py
+++ b/src/spid_sp_test/metadata_private.py
@@ -3,7 +3,6 @@ class SpidSpMetadataCheckPrivate(object):
         self.doc.xpath("//ContactPerson")
         _method = f"{self.__class__.__name__}.test_Contacts_Priv"
         _data = dict(
-            test_id="",
             references=[],
             method=_method,
         )
@@ -13,7 +12,7 @@ class SpidSpMetadataCheckPrivate(object):
             ipacode,
             "The IPACode element MUST NOT be present",
             description=ipacode,
-            **_data,
+            test_id = ['1.12.0'], **_data,
         )
 
         exts = self.doc.xpath("//ContactPerson/Extensions/CessionarioCommittente")
@@ -21,7 +20,7 @@ class SpidSpMetadataCheckPrivate(object):
             (len(exts) == 1),
             ("The CessionarioCommittente element MUST be present"),
             description=exts,
-            **_data,
+            test_id = ['1.14.4'], **_data,
         )
 
         if exts:

--- a/src/spid_sp_test/metadata_public.py
+++ b/src/spid_sp_test/metadata_public.py
@@ -47,7 +47,7 @@ class SpidSpMetadataCheckPublic(object):
                 len(entity_desc) == 1,
                 "Only one ContactPerson element of contactType "
                 f'"{contact_type}" MUST be present',
-                **_data,
+                test_id = ['1.10.0'], **_data,
             )
 
         return self.is_ok(_method)
@@ -66,7 +66,7 @@ class SpidSpMetadataCheckPublic(object):
                 ext_cnt > 1,
                 "Only one Extensions element inside ContactPerson element MUST be present",
                 description=etree.tostring(cont).decode(),
-                **_data,
+                test_id = ['1.10.1'], **_data,
             )
 
         orgs = self.doc.xpath("//EntityDescriptor/Organization/OrganizationName")
@@ -87,7 +87,7 @@ class SpidSpMetadataCheckPublic(object):
                     company.text == org.text,
                     "If the Company element if present it MUST be equal to OrganizationName",
                     description=(company.text, org.text),
-                    **_data,
+                    test_id = ['1.10.3'], **_data,
                 )
 
         return self.is_ok(_method)
@@ -100,20 +100,20 @@ class SpidSpMetadataCheckPublic(object):
             email,
             f"The {email_xpath} element MUST be present",
             description=[etree.tostring(_val).decode() for _val in email],
-            **_data,
+            test_id = ['1.10.4'], **_data,
         )
         if email:
             self._assertTrue(
                 email[0].text,
                 f"The {email_xpath} element MUST have a value",
                 description=[etree.tostring(_val).decode() for _val in email],
-                **_data,
+                test_id = ['1.10.5'], **_data,
             )
             self._assertTrue(
                 re.match(EMAIL_REGEXP, email[0].text),
                 f"The {email_xpath} element MUST be a valid email address",
                 description=[etree.tostring(_val).decode() for _val in email],
-                **_data,
+                test_id = ['1.10.6'], **_data,
             )
         return self.is_ok(_method)
 
@@ -124,20 +124,21 @@ class SpidSpMetadataCheckPublic(object):
         if phone:
             phone = phone[0].text
             self._assertTrue(
-                phone, f"The {phone_xpath} element MUST have a value", **_data
+                phone, f"The {phone_xpath} element MUST have a value",
+                **_data
             )
             self._assertTrue(
                 (" " not in phone),
                 f"The {phone_xpath} element MUST not contain spaces",
                 description=phone,
-                **_data,
+                test_id = ['1.10.8'], **_data,
             )
             self._assertTrue(
                 (phone[0:3] == "+39"),
                 f'The {phone_xpath} element MUST start with "+39"',
                 description=phone,
                 level="warning",
-                **_data,
+                test_id = ['1.10.9'], **_data,
             )
 
         return self.is_ok(_method)
@@ -148,19 +149,20 @@ class SpidSpMetadataCheckPublic(object):
         _data = dict(references=[""], method=_method)
         if self.production:
             ipacode = self.doc.xpath("//ContactPerson/Extensions/IPACode")
-            self._assertTrue(ipacode, "The IPACode element MUST be present", **_data)
+            self._assertTrue(
+                ipacode, "The IPACode element MUST be present",
+                test_id = ['1.11.0'], **_data
+            )
             if ipacode:
                 ipacode = ipacode[0]
                 self._assertTrue(
-                    ipacode.text, "The IPACode element MUST have a value", **_data
-                )
-                self._assertTrue(
-                    ipacode.text, "The IPACode element MUST have a value", **_data
+                    ipacode.text, "The IPACode element MUST have a value",
+                    test_id = ['1.11.1'], **_data
                 )
                 self._assertTrue(
                     get_indicepa_by_ipacode(ipacode.text)[0] == 1,
                     "The IPACode element MUST have a valid value present on IPA",
-                    **_data,
+                    test_id = ['1.11.2'], **_data,
                 )
 
         return self.is_ok(_method)
@@ -177,16 +179,18 @@ class SpidSpMetadataCheckPublic(object):
             ctype,
             f"Missing ContactPerson/Extensions/{ext_type.title()}, "
             "this element MUST be present",
-            **_data,
+            test_id = ['1.11.7', '1.12.5'], **_data,
         )
         if ctype:
             self._assertFalse(
-                ctype[0].text, f"The {ext_type.title()} element MUST be empty", **_data
+                ctype[0].text, f"The {ext_type.title()} element MUST be empty",
+                test_id = ['1.11.8', '1.12.6'], **_data
             )
 
         ctype = self.doc.xpath(f"//ContactPerson/Extensions/{ext_type_not.title()}")
         self._assertFalse(
-            ctype, f"The {ext_type_not.title()} element MUST not be present", **_data
+            ctype, f"The {ext_type_not.title()} element MUST not be present",
+            test_id = ['1.11.9', '1.12.7'], **_data
         )
         return self.is_ok(_method)
 
@@ -203,7 +207,8 @@ class SpidSpMetadataCheckPublic(object):
         )
         if vats:
             self._assertTrue(
-                vats[0].text, "The VATNumber element MUST have a value", **_data
+                vats[0].text, "The VATNumber element MUST have a value",
+                test_id = ['1.11.4'], **_data
             )
             self._assertTrue(
                 (vats[0].text[:2] in ISO3166_CODES),
@@ -221,7 +226,8 @@ class SpidSpMetadataCheckPublic(object):
             )
             fc = fcs[0]
             self._assertTrue(
-                fc.text, "The FiscalCode element MUST have a value", **_data
+                fc.text, "The FiscalCode element MUST have a value",
+                test_id = ['1.11.6'], **_data
             )
         if private and not len(fcs) and not len(vats):
             self._assertTrue(

--- a/src/spid_sp_test/response.py
+++ b/src/spid_sp_test/response.py
@@ -112,6 +112,14 @@ class SpidSpResponseCheck(AbstractSpidCheck):
         self.template_path = kwargs.get("template_path", self.template_path)
 
         self.metadata_etree = kwargs.get("metadata_etree")
+        self.requested_attrs_raw = self.metadata_etree.xpath(
+            "//EntityDescriptor/SPSSODescriptor"
+            "/AttributeConsumingService/RequestedAttribute"
+        )
+        self.requested_attrs = [
+            i.attrib["Name"] for i in self.requested_attrs_raw
+        ]
+
         self.acs_url = self.metadata_etree.xpath(
             "//SPSSODescriptor/AssertionConsumerService[@index=0]"
         )[0].attrib["Location"]
@@ -139,7 +147,11 @@ class SpidSpResponseCheck(AbstractSpidCheck):
             with open(kwargs["attr_json"], "r") as json_data:
                 self.user_attrs = json.loads(json_data.read())
         else:
-            self.user_attrs = settings.ATTRIBUTES
+            # returns ONLY the requested attributes shown in the metadata
+            # otherwise it returns all the attributes (for test purpose)
+            self.user_attrs = {
+                i:settings.ATTRIBUTES[i] for i in self.requested_attrs
+            } or settings.ATTRIBUTES
 
         self.html_path = kwargs.get("html_path")
         self.no_send_response = kwargs.get("no_send_response")
@@ -174,6 +186,7 @@ class SpidSpResponseCheck(AbstractSpidCheck):
 
         self.issuer = self.kwargs.get("issuer", SAML2_IDP_CONFIG["entityid"])
         self.authnreq_attrs = self.authnreq_etree.xpath("/AuthnRequest")[0].attrib
+
         self.authnreq_issuer = self.authnreq_etree.xpath("/AuthnRequest/Issuer")[
             0
         ].attrib["NameQualifier"]

--- a/src/spid_sp_test/response.py
+++ b/src/spid_sp_test/response.py
@@ -203,8 +203,9 @@ class SpidSpResponseCheck(AbstractSpidCheck):
             "SessionIndex": _session_index,
             "Issuer": self.issuer,
             "Audience": self.authnreq_issuer,
-            "AuthnContextClassRef": self.acr
-            or settings.DEFAULT_RESPONSE["AuthnContextClassRef"],
+            "AuthnContextClassRef": (
+                self.acr or settings.DEFAULT_RESPONSE["AuthnContextClassRef"]
+            ),
             "IssueInstantMillis": now.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             "sign_response": settings.DEFAULT_RESPONSE["sign_response"],
             "sign_assertion": settings.DEFAULT_RESPONSE["sign_assertion"],
@@ -299,7 +300,7 @@ class SpidSpResponseCheck(AbstractSpidCheck):
         status_code = f"[http status_code: {res.status_code}]"
         self._assertTrue(
             status,
-            f"{msg}: {status_code}",
+            msg,
             method=f"{self.__class__.__name__}.check_response",
             description=status_code,
             references=[],

--- a/src/spid_sp_test/utils.py
+++ b/src/spid_sp_test/utils.py
@@ -225,14 +225,16 @@ def report_to_html(o):
                         )  # noqa
                         if t["result"] == "success":
                             res.append(
-                                '<div style="background-color: #f2ffe6; padding: 5px; border: 1px solid green; margin: 5px">'
+                                '<div style="background-color: #f2ffe6; '
+                                'padding: 5px; border: 1px solid green; margin: 5px">'
                             )  # noqa
                             res.append(
                                 '<h5 style="color: green">%s</h5>' % t["result"]
                             )  # noqa
                         else:
                             res.append(
-                                '<div style="background-color: #ffebe6; padding: 5px; border: 1px solid red; margin: 5px">'
+                                '<div style="background-color: #ffebe6; '
+                                'padding: 5px; border: 1px solid red; margin: 5px">'
                             )  # noqa
                             res.append(
                                 '<h5 style="color: red">%s</h5>' % t["result"]

--- a/src/spid_sp_test/utils.py
+++ b/src/spid_sp_test/utils.py
@@ -209,42 +209,6 @@ def html_absolute_paths(html_content, url):
     return html.tostring(q)
 
 
-def report_to_html(o):
-    res = []
-    for h1_title in o.keys():
-        res.append("<h1>%s</h1>" % h1_title)
-        for h2_title in o[h1_title].keys():
-            res.append("<h2>%s</h2>" % h2_title)
-            for h3_title in o[h1_title][h2_title].keys():
-                res.append("<h3>%s</h3>" % h3_title)
-                for test_case in o[h1_title][h2_title][h3_title].keys():
-                    res.append("<h4>%s</h4>" % test_case)
-                    for t in o[h1_title][h2_title][h3_title][test_case]:  # noqa
-                        res.append(
-                            "<p><strong>Description:</strong> %s</p>" % t["test"]
-                        )  # noqa
-                        if t["result"] == "success":
-                            res.append(
-                                '<div style="background-color: #f2ffe6; '
-                                'padding: 5px; border: 1px solid green; margin: 5px">'
-                            )  # noqa
-                            res.append(
-                                '<h5 style="color: green">%s</h5>' % t["result"]
-                            )  # noqa
-                        else:
-                            res.append(
-                                '<div style="background-color: #ffebe6; '
-                                'padding: 5px; border: 1px solid red; margin: 5px">'
-                            )  # noqa
-                            res.append(
-                                '<h5 style="color: red">%s</h5>' % t["result"]
-                            )  # noqa
-                        # res.append('<p>Test: %s</p>' % t['test'].replace('\n', '<br/>'))  # noqa
-                        res.append("<p>Obtained value: %s</p>" % t["value"])
-                        res.append("</div>")
-    return "\n".join(res)
-
-
 def load_plugin(plugin_name):
     n1, _, n2 = plugin_name.rpartition(".")
     module = importlib.import_module(n1)


### PR DESCRIPTION
- chore: code linting and style
- chore: Spid QAD codes, metadata WiP from 1.0 to 1.5
- chore: Spid QAD codes, metadata WiP from 1.6 to 1.14
- feat: Returns only the requested attributes, closes #78
- chore: removed deprecated report_to_html util
