### PR TITLE
Fix for finding nested input elements in SAML HTML form

### DIFF
--- a/src/spid_sp_test/utils.py
+++ b/src/spid_sp_test/utils.py
@@ -141,14 +141,14 @@ def saml_from_htmlform(html_content):
     tree = html.fromstring(html_content)
     for elem in tree.xpath("//form"):
         form = elem.attrib
-        inputs = elem.xpath("input")
+        inputs = elem.xpath("//input")
         for i in inputs:
-            if i.attrib["name"] == "SAMLRequest":
-                form["SAMLRequest"] = i.attrib["value"]
-            elif i.attrib["name"] == "SAMLResponse":
-                form["SAMLResponse"] = i.attrib["value"]
-            elif i.attrib["name"] == "RelayState":
-                form["RelayState"] = i.attrib["value"]
+            if i.name == "SAMLRequest":
+                form["SAMLRequest"] = i.value
+            elif i.name == "SAMLResponse":
+                form["SAMLResponse"] = i.value
+            elif i.name == "RelayState":
+                form["RelayState"] = i.value
         return form
 
 


### PR DESCRIPTION
Example of not retrieved **input** elements wrapped in a **div** element:
```
<form action="https://goolex.okta.com/app/goolex_a1_1/exk1hi6xl2jFdGu7A669/sso/saml" method="post">
    <div>
        <input type="hidden" name="SAMLRequest" value="PD9..."/>
        <input type="hidden" name="RelayState" value="RS1"/>
    </div>
    <noscript>
        <div>
            <input type="submit" value="Continue"/>
        </div>
    </noscript>
</form>
```
