### PR TITLE
fix: ACR comparison - closes https://github.com/italia/spid-sp-test/issues/111

### DIFF
--- a/src/spid_sp_test/__init__.py
+++ b/src/spid_sp_test/__init__.py
@@ -7,7 +7,7 @@ from .constants import HTTP_NO_PORT_REGEX
 
 
 BASE_DIR = Path(__file__).resolve().parent
-__version__ = "0.9.22"
+__version__ = "0.9.23"
 __name__ = "spid_sp_test"
 logger = logging.getLogger(__name__)
 

--- a/src/spid_sp_test/responses/response_mods.py
+++ b/src/spid_sp_test/responses/response_mods.py
@@ -8,7 +8,7 @@ def dynamic_acr(check: SpidSpResponseCheck, response_obj: SpidSpResponse, **kwar
         try:
             level_sp = int(check.get_acr()[-1])
             level_idp = int(check.response_attrs["AuthnContextClassRef"][-1])
-            if level_idp > level_sp:
+            if level_idp >= level_sp:
                 response_obj.conf["status_codes"] = [200]
         except Exception:
             pass


### PR DESCRIPTION
the IDP ACR in the response MUST be greater or equal to that requested by the SP
