### PR TITLE
Fix tests

### DIFF
--- a/src/spid_sp_test/responses/templates/case-29.xml
+++ b/src/spid_sp_test/responses/templates/case-29.xml
@@ -1,2 +1,3 @@
 {% extends "base.xml" %}
-{% block AssertionIssuer %}<saml:Issuer Format="urn:oasis:names:tc:SAML:2.0:nameid-format:entity">diversodaentityididp</saml:Issuer>{% endblock %}
+{% block Issuer %}<saml:Issuer Format="urn:oasis:names:tc:SAML:2.0:nameid-format:entity">diversodaentityididp</saml:Issuer>{% endblock %}
+{% block AssertionIssuer %}<saml:Issuer Format="urn:oasis:names:tc:SAML:2.0:nameid-format:entity">{{Issuer}}</saml:Issuer>{% endblock %}

--- a/src/spid_sp_test/responses/templates/case-98.xml
+++ b/src/spid_sp_test/responses/templates/case-98.xml
@@ -1,2 +1,4 @@
 {% extends "base.xml" %}
-{% block AttributeStatement %}{% endblock AttributeStatement %}
+{% block AttributeStatement %}
+<saml:AttributeStatement></saml:AttributeStatement>
+{% endblock AttributeStatement %}

--- a/src/spid_sp_test/responses/templates/case-99.xml
+++ b/src/spid_sp_test/responses/templates/case-99.xml
@@ -1,4 +1,6 @@
 {% extends "base.xml" %}
 {% block AttributeStatement %}
+<saml:AttributeStatement>
     <saml:Attribute Name="spidCode" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic"></saml:Attribute>
+</saml:AttributeStatement>
 {% endblock AttributeStatement %}


### PR DESCRIPTION
A few small things that confused me during testing. I think they are correct on [spid-saml-check](https://github.com/italia/spid-saml-check).

This PR fixes the following:
- Tests 29 and 69 are checking the same thing (see `case-29.xml` and `case-69.xml`). It makes more sense for test 29 to check the Response Issuer instead.
- `case-98.xml` and `case-99.xml` are missing the `<saml:AttributeStatement>` altogether, but their description explicitly says that it should be present.