### PR TITLE
Correctly support all comparisons as per SPID specs

### DIFF
--- a/src/spid_sp_test/__init__.py
+++ b/src/spid_sp_test/__init__.py
@@ -6,7 +6,7 @@ from .constants import HTTP_NO_PORT_REGEX
 
 
 BASE_DIR = Path(__file__).resolve().parent
-__version__ = "1.2.5"
+__version__ = "1.2.6"
 __name__ = "spid_sp_test"
 logger = logging.getLogger(__name__)
 

--- a/src/spid_sp_test/responses/response_mods.py
+++ b/src/spid_sp_test/responses/response_mods.py
@@ -17,12 +17,12 @@ def dynamic_acr(check: SpidSpResponseCheck, response_obj: SpidSpResponse, **kwar
                 f"Spid level {level_idp} = {level_sp} and Comparison is {comparison} => Expecting OK "
             )
             response_obj.conf["status_codes"] = [200]
-        if level_idp > level_sp:
+        elif level_idp > level_sp:
             logger.debug(
                 f"Spid level {level_idp} > {level_sp} and Comparison is {comparison} => Expecting OK "
             )
             response_obj.conf["status_codes"] = [200]
-        if level_idp < level_sp and comparison == "maximum":
+        elif level_idp < level_sp and comparison == "maximum":
             logger.debug(
                 f"Spid level {level_idp} < {level_sp} and Comparison is {comparison} => Expecting OK "
             )

--- a/src/spid_sp_test/responses/response_mods.py
+++ b/src/spid_sp_test/responses/response_mods.py
@@ -7,15 +7,25 @@ logger = logging.getLogger(__name__)
 
 
 def dynamic_acr(check: SpidSpResponseCheck, response_obj: SpidSpResponse, **kwargs):
-    if check.get_acr() != check.response_attrs["AuthnContextClassRef"]:
+    try:
+        level_sp = int(check.get_acr()[-1])
+        level_idp = int(check.response_attrs["AuthnContextClassRef"][-1])
         response_obj.conf["status_codes"] = HTTP_STATUS_ERROR_CODES
-        try:
-            level_sp = int(check.get_acr()[-1])
-            level_idp = int(check.response_attrs["AuthnContextClassRef"][-1])
-            if level_idp > level_sp and check.get_acr_comparison() == "minimum":
-                logger.debug(
-                    f"Spid level {level_idp} > {level_sp} and Comparison is {check.get_acr_comparison()} => Expecting OK "
-                )
-                response_obj.conf["status_codes"] = [200]
-        except Exception:
-            pass
+        comparison = check.get_acr_comparison()
+        if level_idp == level_sp and comparison != "better":
+            logger.debug(
+                f"Spid level {level_idp} = {level_sp} and Comparison is {comparison} => Expecting OK "
+            )
+            response_obj.conf["status_codes"] = [200]
+        if level_idp > level_sp:
+            logger.debug(
+                f"Spid level {level_idp} > {level_sp} and Comparison is {comparison} => Expecting OK "
+            )
+            response_obj.conf["status_codes"] = [200]
+        if level_idp < level_sp and comparison == "maximum":
+            logger.debug(
+                f"Spid level {level_idp} < {level_sp} and Comparison is {comparison} => Expecting OK "
+            )
+            response_obj.conf["status_codes"] = [200]
+    except Exception:
+        pass

--- a/src/spid_sp_test/responses/settings.py
+++ b/src/spid_sp_test/responses/settings.py
@@ -857,7 +857,7 @@ RESPONSE_TESTS = {
     },
     "94": {
         "name": "94. Assertion - Elemento AuthContextClassRef impostato su https://www.spid.gov.it/SpidL1",
-        "description": "Elemento AuthContextClassRef impostato su https://www.spid.gov.it/SpidL1. Il SP ha accettato un ACR diverso o inferiore.",
+        "description": "Elemento AuthContextClassRef impostato su https://www.spid.gov.it/SpidL1. Il SP ha accettato un ACR non compatibile con Comparison e non superiore.",
         "status_codes": [200],
         "path": "base.xml",
         "response": {
@@ -868,7 +868,7 @@ RESPONSE_TESTS = {
     },
     "95": {
         "name": "95. Assertion - Elemento AuthContextClassRef impostato su https://www.spid.gov.it/SpidL2",
-        "description": "Elemento AuthContextClassRef impostato su https://www.spid.gov.it/SpidL2. Il SP ha accettato un ACR diverso o inferiore.",
+        "description": "Elemento AuthContextClassRef impostato su https://www.spid.gov.it/SpidL2. Il SP ha accettato un ACR non compatibile con Comparison e non superiore.",
         "status_codes": [200],
         "path": "base.xml",
         "response": {
@@ -878,7 +878,7 @@ RESPONSE_TESTS = {
     },
     "96": {
         "name": "96. Assertion - Elemento AuthContextClassRef impostato su https://www.spid.gov.it/SpidL3",
-        "description": "Elemento AuthContextClassRef impostato su https://www.spid.gov.it/SpidL3. Il SP ha accettato un ACR diverso o inferiore.",
+        "description": "Elemento AuthContextClassRef impostato su https://www.spid.gov.it/SpidL3. Il SP ha accettato un ACR non compatibile con Comparison e non superiore.",
         "status_codes": [200],
         "path": "base.xml",
         "response": {


### PR DESCRIPTION
In particular, with comparison="exact" the SP must accept even higher
established authentication levels. This should also correctly support
"maximum" and "better".

Closes #124.

@peppelinux I don't know Python, so please bear with me if I made some mistake. In particular, please check that the error handling in dynamic_acr is still correct. I made some tests with my SPID implementation, by trying all comparison values and it seems to work.