### PR TITLE
Updated CIE schema to avoid issue on tag order in ContactPerson

### DIFF
--- a/src/spid_sp_test/xsd/cie/cie.xsd
+++ b/src/spid_sp_test/xsd/cie/cie.xsd
@@ -11,9 +11,9 @@
 				<group ref="cie:PublicGroup" maxOccurs="1"/>
 				<group ref="cie:PrivateGroup" maxOccurs="1"/>
 			</choice>
-			<element ref="cie:Municipality" minOccurs="1" maxOccurs="1"/>
-			<element ref="cie:Province" minOccurs="0" maxOccurs="1"/>
-			<element ref="cie:Country" minOccurs="0" maxOccurs="1"/>
+			<element ref="cie:Municipality" minOccurs="1" />
+			<element ref="cie:Province" minOccurs="0" />
+			<element ref="cie:Country" minOccurs="0" />
 			<any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
 		</sequence>
 	</complexType>
@@ -22,14 +22,17 @@
 			<element ref="cie:Public"/>
 			<element ref="cie:IPACode" minOccurs="1"/>
 			<element ref="cie:IPACategory" minOccurs="0"/>
+			<element ref="cie:VATNumber" minOccurs="0" />
+			<element ref="cie:FiscalCode" minOccurs="0" />
+			<element ref="cie:NACE2Code" minOccurs="0" maxOccurs="unbounded" />
 		</sequence>
 	</group>
 	<group name="PrivateGroup">
 		<sequence>
 			<element ref="cie:Private"/>
-			<element ref="cie:VATNumber" minOccurs="0"/>
-			<element ref="cie:FiscalCode" minOccurs="0" />
-			<element ref="cie:NACE2Code" minOccurs="0" maxOccurs="unbounded"/>
+			<element ref="cie:VATNumber" />
+			<element ref="cie:FiscalCode" />
+			<element ref="cie:NACE2Code" minOccurs="0" maxOccurs="unbounded" />
 		</sequence>
 	</group>
 		


### PR DESCRIPTION
Fixes #115 

- added some missing tag to PublicGroup
- make mandatory VATNumber and FiscalCode in PrivateGroup (I'm not sure about that but [here](https://docs.italia.it/italia/cie/cie-manuale-tecnico-docs/it/master/federazione.html#metadata-sp) says both are mandatory)
- removed some extra code