### PR TITLE
Fixes 2025

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim-buster
+FROM python:3.8-slim-bullseye
 
 LABEL maintainer="Giuseppe De Marco <giuseppe.demarco@teamdigitale.governo.it>"
 

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
         'pysaml2>=6.5.1',
         'xmlschema==1.7.1',
         'requests>=2.25.1',
-        'lxml>=4.6.2',
+        'lxml==5.4.0',
         'Jinja2>=2.11.3',
         'spid_compliant_certificates>=0.5.3'
         # 'sslyze>=4.0.4', # todo

--- a/src/spid_sp_test/authn_request.py
+++ b/src/spid_sp_test/authn_request.py
@@ -12,6 +12,8 @@ import urllib
 import urllib3
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+urllib3.util.connection.HAS_IPV6 = False
+
 
 from lxml import etree
 from spid_sp_test.utils import (
@@ -143,7 +145,7 @@ def get_authn_request(
                 f"{authn_request_str[:128]}"
             )
     else:
-        req_dict = {"verify": verify_ssl, "allow_redirects": False}
+        req_dict = {"verify": verify_ssl, "allow_redirects": True}
         # trigger the authn request
         if request_method.upper() == "GET":
             request = requests_session.get(authn_request_url, **req_dict)

--- a/src/spid_sp_test/metadata.py
+++ b/src/spid_sp_test/metadata.py
@@ -13,6 +13,8 @@ import subprocess
 import urllib3
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+urllib3.util.connection.HAS_IPV6 = False
+
 
 from lxml import etree
 from tempfile import NamedTemporaryFile

--- a/src/spid_sp_test/response.py
+++ b/src/spid_sp_test/response.py
@@ -380,7 +380,7 @@ class SpidSpResponseCheck(AbstractSpidCheck):
             func = load_plugin(self.authn_plugin)
             res = func(ua, self.authn_request_url).response(url, data)
         else:
-            res = ua.post(url, data=data, allow_redirects=True)
+            res = ua.post(url, data=data, allow_redirects=True, verify=False)
         msg = f"Response http status code [{res.status_code}]: {res.content.decode()}"
         self.logger.debug(msg)
         return res


### PR DESCRIPTION
* Dockerfile - move to a supported Debian release (bullseye) whose APT repository is still reachable
* python requirement - hardcode lxml to 5.4.0 to avoid the requirement to install full GCC in Debian
* allow redirects for Keycloak compatibility https://github.com/italia/spid-sp-test/issues/65
* force IPv4 in requests since SPID endpoints not available in IPv6 yet (otherwise not working in IPv6 first envs)
* allow self-signed HTTPS endpoints